### PR TITLE
🐛  Bugfix: dockerfile build fix: pip3 missing + jinja errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,13 @@ RUN apt-get update && apt-get install -y \
 
 # Install deps for SAM Backend
 RUN apt-get install -y \
-    python3.9 \
-    python3.8-venv python3.9-venv \
-    && pip install pip \
-    && pip install awscli aws-sam-cli==1.12.0 \
+    python3.9 python3-pip \
+    python3.8-venv python3.9-venv 
+
+# Keep jinja version to specific to avoid breaking
+# https://www.datasciencelearner.com/importerror-cannot-import-name-escape-from-jinja2-solved/
+RUN pip install pip \
+    && pip install Jinja2==3.0.3 awscli aws-sam-cli==1.12.0 \
     && rm -rf /var/lib/apt/lists/*
 
 # we are able to override the CMD instruction and execute any command successfully. 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,15 @@ RUN apt-get update && apt-get install -y \
     software-properties-common \
     && npm install -g aws-cdk ts-node
 
-# Install deps for SAM Backend
+# Install deps for SAM Backend, including python3-pip
+# Avoid errors with pip not found 
+# https://stackoverflow.com/questions/48588449/docker-issue-bin-sh-pip-not-found/67297734#67297734
 RUN apt-get install -y \
     python3.9 python3-pip \
     python3.8-venv python3.9-venv 
 
 # Keep jinja version to specific to avoid breaking
+# mporterror: cannot import name ‘escape’ from ‘jinja2’ 
 # https://www.datasciencelearner.com/importerror-cannot-import-name-escape-from-jinja2-solved/
 RUN pip install pip \
     && pip install Jinja2==3.0.3 awscli aws-sam-cli==1.12.0 \


### PR DESCRIPTION
# 🐛 Bugfix

* `Pip not found` while building
  * https://stackoverflow.com/questions/48588449/docker-issue-bin-sh-pip-not-found/67297734#67297734
* Jinja method:`Importerror: cannot import name ‘escape’ from ‘jinja2’` after fixing the first problem
  * https://stackoverflow.com/questions/48588449/docker-issue-bin-sh-pip-not-found/67297734#67297734

# 🔊 Logs

* Pip not found
```console 
...
-----
executor failed running [/bin/sh -c apt-get install -y     python3.9     python3.8-venv python3.9-venv     && pip install pip     && pip install awscli aws-sam-cli==1.12.0     && rm -rf /var/lib/apt/lists/*]: exit code: 127
ERROR: Service 'sam' failed to build : Build failed
#7 8.411 Setting up python3.9 (3.9.5-3ubuntu0~20.04.1) ...
#7 9.302 Setting up python3.9-venv (3.9.5-3ubuntu0~20.04.1) ...
#7 9.433 Processing triggers for mime-support (3.64ubuntu1) ...
#7 9.563 /bin/sh: 1: pip: not found
------
executor failed running [/bin/sh -c apt-get install -y     python3.9     python3.8-venv python3.9-venv     && pip install pip     && pip install awscli aws-sam-cli==1.12.0     && rm -rf /var/lib/apt/lists/*]: exit code: 127
ERROR: Service 'sam' failed to build : Build failed
```

* Then, Jinja missing method

```console
$ docker-compose up
Creating containerized-aws-sam_sam_1 ... done
Attaching to containerized-aws-sam_sam_1
sam_1  | Traceback (most recent call last):
sam_1  |   File "/usr/local/bin/sam", line 8, in <module>
sam_1  |     sys.exit(cli())
sam_1  |   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 829, in __call__
sam_1  |     return self.main(*args, **kwargs)
sam_1  |   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 782, in main
sam_1  |     rv = self.invoke(ctx)
sam_1  |   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1259, in invoke
sam_1  |     return _process_result(sub_ctx.command.invoke(sub_ctx))
sam_1  |   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1259, in invoke
sam_1  |     return _process_result(sub_ctx.command.invoke(sub_ctx))
sam_1  |   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1066, in invoke
sam_1  |     return ctx.invoke(self.callback, **ctx.params)
sam_1  |   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 610, in invoke
sam_1  |     return callback(*args, **kwargs)
sam_1  |   File "/usr/local/lib/python3.8/dist-packages/click/decorators.py", line 73, in new_func
sam_1  |     return ctx.invoke(f, obj, *args, **kwargs)
sam_1  |   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 610, in invoke
sam_1  |     return callback(*args, **kwargs)
sam_1  |   File "/usr/local/lib/python3.8/dist-packages/samcli/lib/telemetry/metrics.py", line 100, in wrapped
sam_1  |     return func(*args, **kwargs)
sam_1  |   File "/usr/local/lib/python3.8/dist-packages/samcli/commands/local/start_api/cli.py", line 72, in cli
sam_1  |     do_cli(
sam_1  |   File "/usr/local/lib/python3.8/dist-packages/samcli/commands/local/start_api/cli.py", line 118, in do_cli
sam_1  |     from samcli.commands.local.lib.local_api_service import LocalApiService
sam_1  |   File "/usr/local/lib/python3.8/dist-packages/samcli/commands/local/lib/local_api_service.py", line 9, in <module>
sam_1  |     from samcli.local.apigw.local_apigw_service import LocalApigwService
sam_1  |   File "/usr/local/lib/python3.8/dist-packages/samcli/local/apigw/local_apigw_service.py", line 7, in <module>
sam_1  |     from flask import Flask, request
sam_1  |   File "/usr/local/lib/python3.8/dist-packages/flask/__init__.py", line 14, in <module>
sam_1  |     from jinja2 import escape
sam_1  | ImportError: cannot import name 'escape' from 'jinja2' (/usr/local/lib/python3.8/dist-packages/jinja2/__init__.py)
  1 FROM mcr.microsoft.com/playwright:focal
  2
containerized-aws-sam_sam_1 exited with code 1
```

# 🎉  Solution worked!

```console
$ docker-compose up
Starting containerized-aws-sam_sam_1 ... done
Attaching to containerized-aws-sam_sam_1
sam_1  | Mounting HelloWorldFunction at http://0.0.0.0:3000/hello [GET]
sam_1  | You can now browse to the above endpoints to invoke your functions. You do not need to restart/reload SAM CLI while working on your functions, changes will be reflected instantly/automatically. You only need to restart SAM CLI if you update your AWS SAM template
sam_1  | 2022-07-11 07:58:10  * Running on http://0.0.0.0:3000/ (Press CTRL+C to quit)
```

# ✅ Tests working

```console
$ curl localhost:3000/hello
{"message": "hello world"}%
```

# 🔊  SAM Logs

```console
$ docker-compose up
Starting containerized-aws-sam_sam_1 ... done
Attaching to containerized-aws-sam_sam_1
sam_1  | Mounting HelloWorldFunction at http://0.0.0.0:3000/hello [GET]
sam_1  | You can now browse to the above endpoints to invoke your functions. You do not need to restart/reload SAM CLI while working on your functions, changes will be reflected instantly/automatically. You only need to restart SAM CLI if you update your AWS SAM template
sam_1  | 2022-07-11 07:58:10  * Running on http://0.0.0.0:3000/ (Press CTRL+C to quit)
sam_1  | Invoking app.lambda_handler (python3.8)
sam_1  | Image was not found.
sam_1  | Building image................................................................................................................................................................................................................................
sam_1  | Skip pulling image and use local one: amazon/aws-sam-cli-emulation-image-python3.8:rapid-1.12.0.
sam_1  |
sam_1  | Mounting /Users/marcellodesales/dev/github.com/chrishart0/containerized-aws-sam/hello_world as /var/task:ro,delegated inside runtime container
sam_1  | START RequestId: 8fba7c93-c876-1f6e-e91e-833089f72fcd Version: $LATEST
sam_1  | END RequestId: 8fba7c93-c876-1f6e-e91e-833089f72fcd
sam_1  | REPORT RequestId: 8fba7c93-c876-1f6e-e91e-833089f72fcd	Init Duration: 429.97 ms	Duration: 3.98 ms	Billed Duration: 100 msMemory Size: 128 MB	Max Memory Used: 24 MB
sam_1  | No Content-Type given. Defaulting to 'application/json'.
sam_1  | 2022-07-11 08:00:41 172.26.0.1 - - [11/Jul/2022 08:00:41] "GET /hello HTTP/1.1" 200 -
```
